### PR TITLE
Allowing all deltas to be shown inline

### DIFF
--- a/src/main/java/difflib/DiffRowGenerator.java
+++ b/src/main/java/difflib/DiffRowGenerator.java
@@ -320,7 +320,7 @@ public class DiffRowGenerator {
             revList.add(character.toString());
         }
         List<Delta<String>> inlineDeltas = DiffUtils.diff(origList, revList).getDeltas();
-        if (inlineDeltas.size() < 3) {
+        if (inlineDeltas.size() > 0) {
             Collections.reverse(inlineDeltas);
             for (Delta<String> inlineDelta : inlineDeltas) {
                 Chunk<String> inlineOrig = inlineDelta.getOriginal();


### PR DESCRIPTION
The parent code has a < 3 restriction on showing differences. I think it should either be all differences or the user can specify when they would like to restrict the number of differences to show...