### PR TITLE
fixed the diff rows tag when lines of change is unequal

### DIFF
--- a/src/main/java/difflib/DiffRowGenerator.java
+++ b/src/main/java/difflib/DiffRowGenerator.java
@@ -285,13 +285,27 @@ public class DiffRowGenerator {
                 }
             } else if (orig.size() > rev.size()) {
                 for (int j = 0; j < orig.size(); j++) {
-                    diffRows.add(new DiffRow(Tag.CHANGE, (String) orig.getLines().get(j), rev
-                            .getLines().size() > j ? (String) rev.getLines().get(j) : defaultString));
+
+                    if (j < rev.size()) {
+                        diffRows.add(new DiffRow(Tag.CHANGE, (String) orig.getLines().get(j), (String) rev.getLines()
+                                .get(j)));
+                    }
+                    else {
+                        diffRows.add(new DiffRow(Tag.DELETE, (String) orig.getLines().get(j), defaultString));
+                    }
                 }
-            } else {
+            }
+            else {
                 for (int j = 0; j < rev.size(); j++) {
-                    diffRows.add(new DiffRow(Tag.CHANGE, orig.getLines().size() > j ? (String) orig
-                            .getLines().get(j) : defaultString, (String) rev.getLines().get(j)));
+
+                    if (j < orig.size()) {
+                        diffRows.add(new DiffRow(Tag.CHANGE, (String) orig.getLines().get(j), (String) rev.getLines()
+                                .get(j)));
+                    }
+                    else {
+                        diffRows.add(new DiffRow(Tag.INSERT, defaultString, (String) rev.getLines().get(j)));
+                    }
+
                 }
             }
             endPos = orig.last() + 1;


### PR DESCRIPTION
If a delta is like
`{
  "deltas": [
    {
      "original": {
        "position": 0.0,
        "lines": [
          "first old line"
        ]
      },
      "revised": {
        "position": 0.0,
        "lines": [
          "first new line",
          "second new line"
        ]
      },
      "type": "CHANGE"
    }
  ]
}`
The 2 diff row will be generated as
`[
  {
    "tag": "CHANGE",
    "oldLine": "first old line",
    "newLine": "first new line"
  },
  {
    "tag": "CHANGE",
    "oldLine": "default string",
    "newLine": "second new line"
  }
]`

But the second diff row should be an INSERT not CHANGE.

This pull request fixes the same.
